### PR TITLE
Add missing kwargs to _init_optims and _init_losses

### DIFF
--- a/salad/solver/da/dirtt.py
+++ b/salad/solver/da/dirtt.py
@@ -83,7 +83,7 @@ class VADASolver(DANNSolver):
     def __init__(self, model, discriminator, dataset, *args, **kwargs):
         super(VADASolver, self).__init__(model, discriminator, dataset, *args, **kwargs)
 
-    def _init_optims(self):
+    def _init_optims(self, **kwargs):
         # override original call, but call init of higher class
         DABaseSolver._init_optims(self)
 
@@ -99,7 +99,7 @@ class VADASolver(DANNSolver):
                                     lr=3e-4),
                                 loss_disc)
 
-    def _init_losses(self):
+    def _init_losses(self, **kwargs):
 
         super()._init_losses(cl_weight=1e-2)
 


### PR DESCRIPTION
Great package!

I noticed a small bug when trying to run VADA:

```
$ python scripts/train_digits.py --log ./log --vada --source svhn --target mnist --epochs 10 --gpu 3
Start Experiments
Normalize data
Using downloaded and verified file: /tmp/data/train_32x32.mat
Normalize data
Normalize data
Using downloaded and verified file: /tmp/data/train_32x32.mat
Normalize data
Registered DigitModel as "classifier"
Registered Linear as "discriminator"
Traceback (most recent call last):
  File "scripts/train_digits.py", line 112, in <module>
    experiment = solver.VADASolver(model, disc, loader_plain, **kwargs)
  File "/mnt/matang/salad/salad/solver/da/dirtt.py", line 84, in __init__
    super(VADASolver, self).__init__(model, discriminator, dataset, *args, **kwargs)
  File "/mnt/matang/salad/salad/solver/da/dann.py", line 83, in __init__
    super().__init__(model, dataset, *args, **kwargs)
  File "/mnt/matang/salad/salad/solver/da/base.py", line 49, in __init__
    super(DABaseSolver, self).__init__(*args, **kwargs)
  File "/mnt/matang/salad/salad/solver/classification.py", line 80, in __init__
    super().__init__(dataset=dataset, *args, **kwargs)
  File "/mnt/matang/salad/salad/solver/base.py", line 201, in __init__
    StructuredInit.__init__(self, **kwargs)
  File "/mnt/matang/salad/salad/solver/base.py", line 49, in __init__
    self._init_losses(**kwargs)
TypeError: _init_losses() got an unexpected keyword argument 'learningrate'
```

By making the suggested change, I can run VADA succesfully.

Thanks.